### PR TITLE
RSDK-9378: fix tuple case

### DIFF
--- a/src/tensorflow_module.py
+++ b/src/tensorflow_module.py
@@ -135,6 +135,7 @@ class TensorflowModule(MLModel, Reconfigurable):
         # Do the infer. res might have >1 tensor in it
         res = self.model(data)
 
+
         # Check output against expected length
         if len(self.output_info) < len(res):
             raise Exception(
@@ -147,12 +148,22 @@ class TensorflowModule(MLModel, Reconfigurable):
 
         # Prep outputs for return
         out = {}
-        if len(res) > 1:
+
+        # This result (res) may be a dict with string keys and tensor values
+        # OR it could be a tuple of tensors. 
+        if len(res) ==1:
+            out[self.output_info[0][0]] = np.asarray(res[0])
+            
+        elif isinstance(res, dict):
             for named_tensor in res:
                 out[named_tensor] = np.asarray(res[named_tensor])
+
+        elif isinstance(res,tuple):
+            for i in range(len(res)):
+                out["output_"+ str(i)] = np.asarray(res[i])
         else:
-            name = self.output_info[0][0]
-            out[name] = np.asarray(res[0])
+            return {}
+
 
         return out
 

--- a/src/tensorflow_module.py
+++ b/src/tensorflow_module.py
@@ -135,7 +135,6 @@ class TensorflowModule(MLModel, Reconfigurable):
         # Do the infer. res might have >1 tensor in it
         res = self.model(data)
 
-
         # Check output against expected length
         if len(self.output_info) < len(res):
             raise Exception(


### PR DESCRIPTION
The problem here was actually not related to Darwin or anything but this particular model. Every other TF model thus far returned a dictionary as a response. This one returned a tuple of tensors.  The fix is just to handle that case. Tested on my Mac. 

P.S. I was gonna change the output names to be what the output_info says but those are useless ("Identity_0", "Identity1_0", etc.).  If the result is a dict, it spits out nice names. I think there is a ticket (or should be) to get "nice" tensor names outta other models.  The way it is now (post PR), it'll still work with the remap config we've been using. 