### PR TITLE
RSDK-11066 - Add Keras support to tensorflow-cpu module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,5 @@ dist/archive.tar.gz:
 	tar -czvf dist/archive.tar.gz dist/main
 
 lint:
-	pylint --disable=C0114,C0115,C0116,C0103,C0200,W0719,W4902,W0212,C0301,E1101,E0401,W1201,W0201 src/
+	pylint --disable=C0114,C0115,C0116,C0103,C0303,C0200,W0719,W4902,W0212,C0301,E1101,E0401,W1201,W0201 src/
 

--- a/src/tensorflow_module.py
+++ b/src/tensorflow_module.py
@@ -47,7 +47,7 @@ class TensorflowModule(MLModel, Reconfigurable):
         # If it's a Keras model file, okay. Otherwise, it must be a SavedModel directory
         _, ext = os.path.splitext(model_path)
         if ext.lower() == ".keras":
-            LOGGER.info("Detected Keras model file at " + model_path)
+            LOGGER.warning("Detected Keras model file at %s. Please note that Keras support is limited.",  model_path=1)
             return []
         
         # Add trailing / if not there

--- a/src/tensorflow_module.py
+++ b/src/tensorflow_module.py
@@ -47,7 +47,7 @@ class TensorflowModule(MLModel, Reconfigurable):
         # If it's a Keras model file, okay. Otherwise, it must be a SavedModel directory
         _, ext = os.path.splitext(model_path)
         if ext.lower() == ".keras":
-            LOGGER.warn("Detected Keras model file at ", model_path, ". Please note that Keras support is limited.")
+            LOGGER.info("Detected Keras model file at " + model_path + ". Please note Keras support is limited.")
             return []
         
         # Add trailing / if not there

--- a/src/tensorflow_module.py
+++ b/src/tensorflow_module.py
@@ -44,7 +44,7 @@ class TensorflowModule(MLModel, Reconfigurable):
         if model_path == "":
             raise Exception(model_path_err)
         
-         # If it's a Keras model file, okay. Otherwise, it must be a SavedModel directory
+        # If it's a Keras model file, okay. Otherwise, it must be a SavedModel directory
         _, ext = os.path.splitext(model_path)
         if ext.lower() == ".keras":
             LOGGER.info("Detected Keras model file at " + model_path)
@@ -61,7 +61,7 @@ class TensorflowModule(MLModel, Reconfigurable):
             raise Exception(model_path_err)
         for file in os.listdir(model_path):
             if ".pb" in file:
-                isValid = True
+                isValidSavedModel = True
                 sizeMB = os.stat(model_path + file).st_size / (1024 * 1024)
                 if sizeMB > 500:
                     LOGGER.warn(
@@ -97,7 +97,7 @@ class TensorflowModule(MLModel, Reconfigurable):
 
             # Keras model's output config's dtype is (sometimes?) a whole dict
             outType = out_config.get("dtype")  
-            if type(outType) is not str:
+            if not isinstance(outType, str):
                 outType = None
 
             self.input_info.append((in_config.get("name"), in_config.get("batch_shape"), in_config.get("dtype")))
@@ -249,7 +249,7 @@ def prepShape(tensorShape):
 
 # Want to return a simple string ("float32", "int64", etc.)
 def prepType(tensorType, is_keras):
-    if tensorType is None or type(tensorType) is not str:
+    if tensorType is None or not isinstance(tensorType):
         return "unknown"
     if is_keras:
         return tensorType

--- a/src/tensorflow_module.py
+++ b/src/tensorflow_module.py
@@ -185,7 +185,7 @@ class TensorflowModule(MLModel, Reconfigurable):
         # OR it could be a tuple of tensors. 
         if len(res) ==1:
             out[self.output_info[0][0]] = np.asarray(res[0])
-            
+
         elif isinstance(res, dict):
             for named_tensor in res:
                 out[named_tensor] = np.asarray(res[named_tensor])
@@ -249,7 +249,7 @@ def prepShape(tensorShape):
 
 # Want to return a simple string ("float32", "int64", etc.)
 def prepType(tensorType, is_keras):
-    if tensorType is None or not isinstance(tensorType):
+    if tensorType is None or not isinstance(tensorType, str):
         return "unknown"
     if is_keras:
         return tensorType
@@ -258,5 +258,3 @@ def prepType(tensorType, is_keras):
     s = str(tensorType)
     inds = [i for i, letter in enumerate(s) if letter == "'"]
     return s[inds[0] + 1 : inds[1]]
-
-

--- a/src/tensorflow_module.py
+++ b/src/tensorflow_module.py
@@ -47,7 +47,7 @@ class TensorflowModule(MLModel, Reconfigurable):
         # If it's a Keras model file, okay. Otherwise, it must be a SavedModel directory
         _, ext = os.path.splitext(model_path)
         if ext.lower() == ".keras":
-            LOGGER.warning("Detected Keras model file at %s. Please note that Keras support is limited.",  model_path=1)
+            LOGGER.warn("Detected Keras model file at ", model_path, ". Please note that Keras support is limited.")
             return []
         
         # Add trailing / if not there

--- a/src/tensorflow_module.py
+++ b/src/tensorflow_module.py
@@ -37,7 +37,7 @@ class TensorflowModule(MLModel, Reconfigurable):
 
     @classmethod
     def validate_config(cls, config: ServiceConfig) -> Sequence[str]:
-        model_path_err = "model_path must be the location of the Tensorflow SavedModel directory" \
+        model_path_err = "model_path must be the location of the Tensorflow SavedModel directory " \
                 "or the location of a Keras model file (.keras)"
         
         model_path = config.attributes.fields["model_path"].string_value

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -38,7 +38,7 @@ class TestTensorflowCPU:
         tfm = TensorflowModule("test")
         with pytest.raises(Exception):
             response = tfm.validate_config(config=self.empty_config)
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(Exception):
             response = tfm.validate_config(config=self.badconfig)
         response = tfm.validate_config(config=self.goodconfig)
 


### PR DESCRIPTION
Hiii,

You're looking at the changes necessary for the tensorflow-cpu module to handle keras files.  Tested this with our LSTM .keras file by making my Mac into a machine and running Python SDK script.  We may eventually want to do more with this (try harder to get metadata, add support for loading .h5 models, etc.) but we should be in great shape for this upcoming demo.  I'm gonna put an rc version up on the registry soon/now. 