### PR TITLE
Return model_path in error

### DIFF
--- a/src/tensorflow_module.py
+++ b/src/tensorflow_module.py
@@ -37,14 +37,10 @@ class TensorflowModule(MLModel, Reconfigurable):
     def validate_config(
         cls, config: ServiceConfig
     ) -> Tuple[Sequence[str], Sequence[str]]:
-        model_path_err = (
-            "model_path must be the location of the Tensorflow SavedModel directory "
-            "or the location of a Keras model file (.keras)"
-        )
-
         model_path = config.attributes.fields["model_path"].string_value
+        
         if model_path == "":
-            raise Exception(model_path_err)
+            raise Exception(get_model_path_error(model_path))
 
         # If it's a Keras model file, okay. Otherwise, it must be a SavedModel directory
         _, ext = os.path.splitext(model_path)
@@ -64,7 +60,7 @@ class TensorflowModule(MLModel, Reconfigurable):
         # and that the model file isn't too big (>500 MB)
         isValidSavedModel = False
         if not os.path.isdir(model_path):
-            raise Exception(model_path_err)
+            raise Exception(get_model_path_error(model_path))
         for file in os.listdir(model_path):
             if ".pb" in file:
                 isValidSavedModel = True
@@ -77,7 +73,7 @@ class TensorflowModule(MLModel, Reconfigurable):
                     )
 
         if not isValidSavedModel:
-            raise Exception(model_path_err)
+            raise Exception(get_model_path_error(model_path))
 
         return ([], [])
 
@@ -293,3 +289,8 @@ def prepType(tensorType, is_keras):
     s = str(tensorType)
     inds = [i for i, letter in enumerate(s) if letter == "'"]
     return s[inds[0] + 1 : inds[1]]
+
+
+def get_model_path_error(model_path: str) -> str:
+    """Generate informative error message for model_path validation failures."""
+    return f"Invalid model_path '{model_path}'. model_path must be the location of the Tensorflow SavedModel directory or the location of a Keras model file (.keras)"


### PR DESCRIPTION
As a result of a conversation with Dan, we decided it would be a good idea to log the model_path in the error. 

<img width="1182" height="803" alt="Screenshot 2025-09-19 at 1 22 42 PM" src="https://github.com/user-attachments/assets/1a172cdd-3a9f-4018-b1f9-9e27424d824a" />
